### PR TITLE
fix: add packageManager field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=20.0.0",
     "pnpm": ">=8.0.0"
   },
+  "packageManager": "pnpm@8.15.6",
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",


### PR DESCRIPTION
## Summary
- Turbo 2.x requires `packageManager` field in package.json
- Added `"packageManager": "pnpm@8.15.6"` to fix build errors

## Problem
When running `pnpm build`, the following error occurred:
```
× Missing `packageManager` field in package.json
```

## Solution
Added the `packageManager` field to specify the exact version of pnpm to use across all environments.

## Test plan
- [x] Run `pnpm install`
- [x] Run `pnpm build`
- [x] Verify no errors related to missing packageManager field

🤖 Generated with [Claude Code](https://claude.ai/code)